### PR TITLE
Better initialization command

### DIFF
--- a/res/values/strings_activity_settings.xml
+++ b/res/values/strings_activity_settings.xml
@@ -31,7 +31,7 @@
     <string name="pref_description_keyboard_autoclear">Clear keyboard input on send</string>
     <string name="pref_title_keyboard_autoclear">Auto clear keystrokes</string>
     
-    <string name="pref_defualt_xdotool_initial">export DISPLAY=$(who -u | grep -o \"$USER  :[0-9]\\+\" | grep -o \":[0-9]\\+\")</string>
+    <string name="pref_defualt_xdotool_initial">export DISPLAY=$(who -u | grep -o \"$USER\\s\\s:[0-9]\\+\" | grep -o \":[0-9]\\+\")</string>
     <string name="pref_title_xdotool_initial">Initialization command</string>
     
     <string-array name="pref_sensitivity_list_titles">


### PR DESCRIPTION
export DISPLAY=\':0\' which translates to export DISPLAY=':0' 
has been changed to 
export DISPLAY=$(who -u | grep -o \"$USER\s\s:[0-9]\+\" | grep -o \":[0-9]\+\") which translates to export DISPLAY=$(who -u | grep -o "$USER\s\s:[0-9]\+" | grep -o ":[0-9]\+")

The double greped who command is a dynamic replacement for the static default assignment of display :0. This dynamic command should always evaluate to whichever display USER is currently using X for. This is useful if other users are logged onto the same computer as the "switch user" method of logging on creates a new desktop eg: DESKTOP=:1. 

This has been tested on my computer for :0 and :1 and should work for most basic circumstances. However I do not know how it will respond if the user has created multiple desktop instances eg: via vnc4server.
