### PR TITLE
Only send integer coordinates to xdotool

### DIFF
--- a/app/src/main/java/com/stripe1/xmouse/MyMouseView.java
+++ b/app/src/main/java/com/stripe1/xmouse/MyMouseView.java
@@ -36,6 +36,9 @@ public class MyMouseView extends View {
     boolean draggable = true;
     boolean touching = false;
 
+    // coordinate rounding errors
+    private float reX = 0;
+    private float reY = 0;
 
     enum ClickType {
 
@@ -338,6 +341,14 @@ public class MyMouseView extends View {
 
         dx=dx*MainActivity.setting_sensitivity;
         dy=dy*MainActivity.setting_sensitivity;
+
+        dx += reX;
+        dy += reY;
+        reX = dx - Math.round(dx);
+        reY = dy - Math.round(dy);
+        dx -= reX;
+        dy -= reY;
+
         String cmd="";
         if(dx <0 || dy <0){
             cmd="xdotool mousemove_relative -- "+dx+" "+dy;


### PR DESCRIPTION
Store the corresponding rounding error inside the app

Rationale: xdotool actually rounds the movement, so moving 10 times by
+1.1 then one time back by -11 is not returning to the initial point.
This is especially annoying when trying to draw