### PR TITLE
jsch: switch to an active fork, bump version

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -27,7 +27,7 @@ android {
 
 dependencies {
     testCompile 'junit:junit:4.12'
-    compile 'com.jcraft:jsch:0.1.55'
+    compile 'com.github.mwiede:jsch:0.1.70'
     compile 'com.madgag.spongycastle:core:1.58.0.0'
     compile 'com.madgag.spongycastle:prov:1.58.0.0'
     compile 'com.madgag.spongycastle:pkix:1.54.0.0'


### PR DESCRIPTION
Old jsch supports no encryption algorithms that are still enabled by default in the freshest OpenSSH