### PR TITLE
Make XMouse work with newer ssh keys

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -29,7 +29,7 @@ dependencies {
     testImplementation 'org.mockito:mockito-core:4.6.1'
     testImplementation 'org.mockito:mockito-inline:4.6.1'
     testImplementation 'com.tngtech.java:junit-dataprovider:1.13.1'
-    implementation 'com.jcraft:jsch:0.1.55'
+    implementation 'com.github.mwiede:jsch:0.2.7'
     implementation 'com.madgag.spongycastle:core:1.58.0.0'
     implementation 'com.madgag.spongycastle:prov:1.58.0.0'
     implementation 'com.madgag.spongycastle:pkix:1.54.0.0'


### PR DESCRIPTION
This simple change allows new ssh keys to be used.